### PR TITLE
Fix oh-my-zsh install issue in zsh setup script

### DIFF
--- a/script/setup/zsh
+++ b/script/setup/zsh
@@ -9,7 +9,10 @@ source "/$DOTFILES_ROOT/lib/functions"
 
 if [ ! -d ~/.oh-my-zsh ] && [ "$TRAVIS" != "true" ]; then
   brew install wget
-  sh -c "$(wget https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
+  #sh -c "$(wget https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O -)"
+  # need to remove "env zsh -l" at end of script to avoid exiting before the rest of this script
+  # (will revert when oh-my-zsh adds a --silent option, see https://github.com/robbyrussell/oh-my-zsh/pull/6547)
+  sh -c "$(wget https://raw.github.com/robbyrussell/oh-my-zsh/master/tools/install.sh -O - | sed 's:env zsh -l::g' | sed 's:chsh -s .*$::g')"
 
   # Remove default .zshrc file so we can link_safe our own
   rm -f ~/.zshrc


### PR DESCRIPTION
Installing oh-my-zsh in the zsh setup script currently prevents the rest of the script from completing, since it runs `env zsh -l` when completing. Until oh-my-zsh adds a --silent option (or similar), the script needs to be modified to remove this command.