### PR TITLE
Prepare for new laptop migration

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -20,8 +20,6 @@ brew 'libyaml'
 brew 'ansible'
 # Checks ansible playbooks for practices and behaviour
 brew 'ansible-lint'
-# Extendable version manager with support for Ruby, Node.js, Erlang & more
-brew 'asdf'
 # Microsoft Azure CLI 2.0
 brew 'azure-cli'
 # Bash Automated Testing System
@@ -132,6 +130,8 @@ brew 'mas'
 brew 'openjdk'
 # Java-based project management
 brew 'maven'
+# Polyglot runtime manager (asdf rust clone)
+brew 'mise'
 # 'traceroute' and 'ping' in a single tool
 brew 'mtr'
 # Port scanning utility for large networks

--- a/Brewfile
+++ b/Brewfile
@@ -1,370 +1,394 @@
+# frozen_string_literal: true
 
-tap "github/bootstrap"
-
-
+tap 'cloudflare/cloudflare'
+tap 'github/bootstrap'
 # Run your GitHub Actions locally
-brew "act"
+brew 'act'
 # GNU multiple precision arithmetic library
-brew "gmp"
+brew 'gmp'
 # Static analysis and lint tool, for (ba)sh scripts
-brew "shellcheck"
+brew 'shellcheck'
 # Static checker for GitHub Actions workflow files
-brew "actionlint"
-# Software library to render fonts
-brew "freetype"
-# OpenType text shaping engine
-brew "harfbuzz"
-# Library to render SVG files using Cairo
-brew "librsvg"
+brew 'actionlint'
 # Cryptography and SSL/TLS Toolkit
-brew "openssl@3"
+brew 'openssl@3'
 # C library SSHv1/SSHv2 client and server protocols
-brew "libssh"
+brew 'libssh'
 # YAML Parser
-brew "libyaml"
+brew 'libyaml'
 # Automate deployment, configuration, and upgrading
-brew "ansible"
+brew 'ansible'
 # Checks ansible playbooks for practices and behaviour
-brew "ansible-lint"
-# Distributed revision control system
-brew "git"
+brew 'ansible-lint'
 # Extendable version manager with support for Ruby, Node.js, Erlang & more
-brew "mise"
-# TAP-compliant test framework for Bash
-brew "bats-core"
+brew 'asdf'
+# Microsoft Azure CLI 2.0
+brew 'azure-cli'
+# Bash Automated Testing System
+brew 'bats-core'
 # Powerful, enterprise-ready, open source web server with automatic HTTPS
-brew "caddy", restart_service: :changed
+brew 'caddy', restart_service: :changed
+# Software library to render fonts
+brew 'freetype'
 # Statistics utility to count lines of code
-brew "cloc"
+brew 'cloc'
 # Cross-platform make
-brew "cmake"
+brew 'cmake'
 # GNU File, Shell, and Text utilities
-brew "coreutils"
+brew 'coreutils'
 # C library implementing the SSH2 protocol
-brew "libssh2"
+brew 'libssh2'
 # Get a file from an HTTP, HTTPS or FTP server
-brew "curl"
-# Good-lookin' diffs with diff-highlight and more
-brew "delta"
+brew 'curl'
 # Tool for managing dock items
-brew "dockutil"
+brew 'dockutil'
 # Read, write, modify, and display EXIF data on the command-line
-brew "exif"
+brew 'exif'
 # Perl lib for reading and writing EXIF metadata
-brew "exiftool"
-# GNU Transport Layer Security (TLS) Library
-brew "gnutls"
+brew 'exiftool'
 # Low-level access to audio, keyboard, mouse, joystick, and graphics
-brew "sdl2"
-# Play, record, convert, and stream audio and video
-brew "ffmpeg"
+brew 'sdl2'
+# Play, record, convert, and stream select audio and video codecs
+brew 'ffmpeg'
 # Command-line fuzzy finder written in Go
-brew "fzf"
+brew 'fzf'
+# JPEG image codec that aids compression and decompression
+brew 'jpeg-turbo'
+# TIFF library and utilities
+brew 'libtiff'
 # GitHub command-line tool
-brew "gh"
+brew 'gh'
+# OpenType text shaping engine
+brew 'harfbuzz'
+# Interpreter for PostScript and PDF
+brew 'ghostscript'
+# Distributed revision control system
+brew 'git'
+# Syntax-highlighting pager for git and diff output
+brew 'git-delta'
 # Quickly rewrite git repository history
-brew "git-filter-repo"
+brew 'git-filter-repo'
 # Git extension for versioning large files
-brew "git-lfs"
+brew 'git-lfs'
+# Audit git repos for secrets
+brew 'gitleaks'
 # GNU implementation of the famous stream editor
-brew "gnu-sed"
+brew 'gnu-sed'
+# GNU Transport Layer Security (TLS) Library
+brew 'gnutls'
 # Passphrase entry dialog utilizing the Assuan protocol
-brew "pinentry"
-# GNU Pretty Good Privacy (PGP) package
-brew "gnupg"
-# Package compiler and linker metadata toolkit
-brew "pkgconf"
+brew 'pinentry'
+# GNU Privacy Guard (OpenPGP)
+brew 'gnupg'
 # Open source programming language to build simple/reliable/efficient software
-brew "go"
+brew 'go'
 # Ping, but with a graph
-brew "gping"
+brew 'gping'
 # Colorize logfiles and command output
-brew "grc"
+brew 'grc'
 # GNU grep, egrep and fgrep
-brew "grep"
+brew 'grep'
 # Smarter Dockerfile linter to validate best practices
-brew "hadolint"
+brew 'hadolint'
+# Package compiler and linker metadata toolkit
+brew 'pkgconf'
 # Process manager for Procfile-based applications
-brew "hivemind"
+brew 'hivemind'
 # User-friendly cURL replacement (command-line HTTP client)
-brew "httpie"
+brew 'httpie'
 # C/C++ and Java libraries for Unicode and globalization
-brew "icu4c@76"
+brew 'icu4c@76'
 # ISO/IEC 23008-12:2017 HEIF file format decoder and encoder
-brew "libheif"
+brew 'libheif'
 # Generic library support script
-brew "libtool"
-# Tools and libraries to manipulate images in many formats
-brew "imagemagick"
+brew 'libtool'
+# Tools and libraries to manipulate images in select formats
+brew 'imagemagick'
 # Convert images to PDF via direct JPEG inclusion
-brew "img2pdf"
+brew 'img2pdf'
 # Tool to measure maximum TCP and UDP bandwidth
-brew "iperf"
+brew 'iperf'
 # JSON diff and patch
-brew "jd"
+brew 'jd'
 # Implementation of malloc emphasizing fragmentation avoidance
-brew "jemalloc"
+brew 'jemalloc'
 # Command-line pager for JSON data
-brew "jless"
+brew 'jless'
 # Lightweight and flexible command-line JSON processor
-brew "jq"
+brew 'jq'
 # Domain specific configuration language for defining JSON data
-brew "jsonnet"
+brew 'jsonnet'
 # Development kit for the Java programming language
-brew "openjdk@17"
+brew 'openjdk@17'
 # Style and grammar checker
-brew "languagetool", restart_service: :changed
-# Platform built on V8 to build network applications
-brew "node"
+brew 'languagetool', restart_service: :changed
+# Library to render SVG files using Cairo
+brew 'librsvg'
 # Keep your Mac's application settings in sync
-brew "mackup"
+brew 'mackup'
 # Mac App Store command-line interface
-brew "mas"
+brew 'mas'
+# Development kit for the Java programming language
+brew 'openjdk'
 # Java-based project management
-brew "maven"
+brew 'maven'
 # 'traceroute' and 'ping' in a single tool
-brew "mtr"
+brew 'mtr'
 # Port scanning utility for large networks
-brew "nmap"
+brew 'nmap'
+# Open-source, cross-platform JavaScript runtime environment
+brew 'node'
 # Install NodeJS versions
-brew "node-build"
+brew 'node-build'
 # Find newer versions of dependencies than what your package.json allows
-brew "npm-check-updates"
+brew 'npm-check-updates'
 # Libraries for security-enabled client and server applications
-brew "nss"
+brew 'nss'
 # Adds an OCR text layer to scanned PDF files
-brew "ocrmypdf"
+brew 'ocrmypdf'
 # Open source suite of directory software
-brew "openldap"
+brew 'openldap'
 # Swiss-army knife of markup format conversion
-brew "pandoc"
+brew 'pandoc'
+# Port of pdftk in java
+brew 'pdftk-java'
 # Pinentry for GPG on Mac
-brew "pinentry-mac"
-# An extremely fast Python package and project manager
-brew "uv"
+brew 'pinentry-mac'
 # Execute binaries from Python packages in isolated environments
-brew "pipx"
+brew 'pipx'
 # Code formatter for JavaScript, CSS, JSON, GraphQL, Markdown, YAML
-brew "prettier"
+brew 'prettier'
 # Protocol buffers (Google's data interchange format)
-brew "protobuf"
-# Install various Ruby versions and implementations
-brew "ruby-build"
+brew 'protobuf'
 # Search tool like grep and The Silver Searcher
-brew "ripgrep"
+brew 'ripgrep'
 # Powerful, clean, object-oriented scripting language
-brew "ruby"
+brew 'ruby'
+# Install various Ruby versions and implementations
+brew 'ruby-build'
 # Safe, concurrent, practical language
-brew "rust"
+brew 'rust'
 # SDL2 graphics drawing primitives and other support functions
-brew "sdl2_gfx"
+brew 'sdl2_gfx'
 # Library for loading images as SDL surfaces and textures
-brew "sdl2_image"
+brew 'sdl2_image'
 # Sample multi-channel audio mixer library
-brew "sdl2_mixer"
+brew 'sdl2_mixer'
 # Small sample cross-platform networking library
-brew "sdl2_net"
+brew 'sdl2_net'
 # Library for using TrueType fonts in SDL applications
-brew "sdl2_ttf"
+brew 'sdl2_ttf'
 # Autoformat shell script source code
-brew "shfmt"
-# Cross-shell prompt
-brew "starship"
+brew 'shfmt'
+# Cross-shell prompt for astronauts
+brew 'starship'
+# Tool to build, change, and version infrastructure
+brew 'terraform'
 # Detect compliance and security violations across Infrastructure as Code
-brew "terrascan"
+brew 'terrascan'
 # Enables extra languages support for Tesseract
-brew "tesseract-lang"
+brew 'tesseract-lang'
 # Linter for Terraform files
-brew "tflint"
+brew 'tflint'
 # Static analysis security scanner for your terraform code
-brew "tfsec"
+brew 'tfsec'
 # Clean up files in directories based on their age
-brew "tmpreaper"
+brew 'tmpreaper'
 # Language for application scale JavaScript development
-brew "typescript"
+brew 'typescript'
+# Extremely fast Python package installer and resolver, written in Rust
+brew 'uv'
 # Syntax-aware linter for prose
-brew "vale"
+brew 'vale'
 # Image processing library
-brew "vips"
+brew 'vips'
 # Convert HTML to PDF
-brew "weasyprint"
+brew 'weasyprint'
 # Internet file retriever
-brew "wget"
+brew 'wget'
 # Linter for YAML files
-brew "yamllint"
+brew 'yamllint'
 # JavaScript package manager
-brew "yarn"
+brew 'yarn'
 # Process YAML, JSON, XML, CSV and properties documents from the CLI
-brew "yq"
+brew 'yq'
 # Shell extension to navigate your filesystem faster
-brew "zoxide"
+brew 'zoxide'
 # UNIX shell (command interpreter)
-brew "zsh"
+brew 'zsh'
 # Utility to export your existing Cloudflare resources as Terraform resources
-brew "cloudflare/cloudflare/cf-terraforming"
+brew 'cloudflare/cloudflare/cf-terraforming'
 # Password manager that keeps all passwords secure behind one password
-cask "1password"
+cask '1password'
 # Command-line interface for 1Password
-cask "1password-cli"
-# Android SDK component
-cask "apparency"
+cask '1password-cli'
+# Inspect application bundles
+cask 'apparency'
 # USB 3.0 to gigabit ethernet drivers for ASIX Electronics devices
-cask "asix-ax88179"
-# Two-factor authentication software
-cask "bruno"
+cask 'asix-ax88179'
+# Open source IDE for exploring and testing APIs
+cask 'bruno'
+# Utility that prevents the system from going to sleep
+cask 'caffeine'
 # Use your phone as a high-quality webcam with image tuning controls
-cask "camo-studio"
+cask 'camo-studio'
 # Drivers for DisplayLink docks, adapters and monitors
-cask "displaylink"
+cask 'displaylink'
 # App to build and share containerised applications and microservices
-cask "docker-desktop"
+cask 'docker-desktop'
 # Client for the Dropbox cloud storage service
-cask "dropbox"
+cask 'dropbox'
 # Elgato FACECAM configuration tool
-cask "elgato-camera-hub"
+cask 'elgato-camera-hub'
 # Control your Elgato key lights
-cask "elgato-control-center"
+cask 'elgato-control-center'
 # Assign keys, and then decorate and label them
-cask "elgato-stream-deck"
-cask "font-hack-nerd-font"
+cask 'elgato-stream-deck'
+cask 'font-hack-nerd-font'
 # Terminal emulator that uses platform-native UI and GPU acceleration
-cask "ghostty"
-# Free and open-source image editor
-cask "github@beta"
+cask 'ghostty'
+# Desktop client for GitHub repositories
+cask 'github@beta'
 # Web browser
-cask "google-chrome"
+cask 'google-chrome'
 # Client for the Google Drive storage service
-cask "google-drive"
+cask 'google-drive'
 # Tools to protect your emails and files
-cask "gpg-suite"
+cask 'gpg-suite'
 # Terminal emulator as alternative to Apple's Terminal app
-cask "iterm2@beta"
+cask 'iterm2@beta'
 # Keyboard customiser
-cask "karabiner-elements"
+cask 'karabiner-elements'
 # Grammar, spelling and style suggestions in all the writing apps
-cask "languagetool-desktop"
+cask 'languagetool-desktop'
 # Software for Logitech devices
-cask "logi-options+"
+cask 'logi-options+'
 # Provides updates to various Microsoft products
-cask "microsoft-auto-update"
+cask 'microsoft-auto-update'
 # Multi-platform web browser
-cask "microsoft-edge"
+cask 'microsoft-edge'
 # Office suite
-cask "microsoft-office"
+cask 'microsoft-office'
 # Meet, chat, call, and collaborate in just one place
-cask "microsoft-teams"
+cask 'microsoft-teams'
 # Intercept, modify, replay, save HTTP/S traffic
-cask "mitmproxy"
+cask 'mitmproxy'
 # Cross-platform MQTT 5.0 Desktop Client
-cask "mqttx"
+cask 'mqttx'
 # Toggle mute, video, record, share, and leave a meeting in a call app
-cask "mutedeck"
+cask 'mutedeck'
 # Open-source software for live streaming and screen recording
-cask "obs"
+cask 'obs'
 # Network utility for sending / receiving TCP, UDP, SSL
-cask "packetsender"
+cask 'packetsender'
 # Extracts pages, splits, merges, mixes and rotates PDF files
-cask "pdfsam-basic"
+cask 'pdfsam-basic'
 # Companion app for Flipper Zero devices
-cask "qflipper"
+cask 'qflipper'
 # Quick Look plug-in that renders source code with syntax highlighting
-cask "qlcolorcode"
+cask 'qlcolorcode'
 # Display image info and preview unsupported formats in QuickLook
-cask "qlimagesize"
+cask 'qlimagesize'
 # Quick Look generator for Markdown files
-cask "qlmarkdown"
+cask 'qlmarkdown'
 # Quick Look plugin for plaintext files without an extension
-cask "qlstephen"
+cask 'qlstephen'
 # Quick Look plugin for GeoJSON and TopoJSON
-cask "quickgeojson"
+cask 'quickgeojson'
 # Quick Look plugin for CSV files
-cask "quicklook-csv"
+cask 'quicklook-csv'
 # Quick Look generator for Adobe Swatch Exchange files
-cask "quicklookase"
+cask 'quicklookase'
 # Imaging utility to install operating systems to a microSD card
-cask "raspberry-pi-imager"
+cask 'raspberry-pi-imager'
 # Screenshot measurement and annotation tool
-cask "shottr"
+cask 'shottr'
 # Instant messaging application focusing on security
-cask "signal"
+cask 'signal'
 # Team communication and collaboration software
-cask "slack@beta"
+cask 'slack@beta'
 # Music streaming service
-cask "spotify"
+cask 'spotify'
 # Video game digital distribution service
-cask "steam"
+cask 'steam'
 # Application for inspecting installer packages
-cask "suspicious-package"
+cask 'suspicious-package'
 # Mutes your keyboard while you type
-cask "unclack"
+cask 'unclack'
 # Management tool for Unity
-cask "unity-hub"
+cask 'unity-hub'
 # Open-source code editor
-cask "visual-studio-code"
+cask 'visual-studio-code'
 # Open-source code editor
-cask "visual-studio-code@insiders"
-# Application for generating TOTP and HOTP codes
-cask "yubico-authenticator"
+cask 'visual-studio-code@insiders'
+# Full-featured companion app to the YubiKey
+cask 'yubico-authenticator'
 # Video communication and virtual meeting platform
-cask "zoom"
-mas "1Password for Safari", id: 1569813296
-mas "24 Hour Wallpaper", id: 1226087575
-mas "AdGuard for Safari", id: 1440147259
-mas "Dark Reader for Safari", id: 1438243180
-mas "DuckDuckGo Privacy for Safari", id: 1482920575
-mas "GhostText", id: 1552641506
-mas "Hush", id: 1544743900
-mas "iMovie", id: 408981434
-mas "JSONPeep", id: 1458969831
-mas "Keynote", id: 409183694
-mas "Kindle", id: 302584613
-mas "MeetingBar", id: 1532419400
-mas "Meshtastic", id: 1586432531
-mas "Okta Extension App", id: 1439967473
-mas "Open In Webmail", id: 1451552749
-mas "PayPal Honey", id: 1472777122
-mas "reMarkable", id: 1276493162
-mas "RetailMeNot Codes & Cash Back", id: 1588381926
-mas "Ring", id: 1142753258
-mas "StopTheMadness", id: 1376402589
-mas "Super Agent", id: 1568262835
-mas "TestFlight", id: 899247664
-mas "URL Linker", id: 1289119450
-mas "Wayback Machine", id: 1472432422
-mas "WhatsApp", id: 310633997
-vscode "1password.op-vscode"
-vscode "christian-kohler.npm-intellisense"
-vscode "davidanson.vscode-markdownlint"
-vscode "docker.docker"
-vscode "ginfuru.ginfuru-vscode-jekyll-syntax"
-vscode "github.codespaces"
-vscode "github.copilot"
-vscode "github.copilot-chat"
-vscode "github.copilot-workspace"
-vscode "github.github-vscode-theme"
-vscode "github.vscode-github-actions"
-vscode "github.vscode-pull-request-github"
-vscode "kargware.vscode-extension-jekyll-kw"
-vscode "mechatroner.rainbow-csv"
-vscode "ms-azuretools.vscode-containers"
-vscode "ms-dotnettools.csdevkit"
-vscode "ms-dotnettools.csharp"
-vscode "ms-dotnettools.vscode-dotnet-runtime"
-vscode "ms-vscode-remote.remote-containers"
-vscode "ms-vscode-remote.remote-ssh"
-vscode "ms-vscode-remote.remote-ssh-edit"
-vscode "ms-vscode-remote.remote-wsl"
-vscode "ms-vscode-remote.vscode-remote-extensionpack"
-vscode "ms-vscode.makefile-tools"
-vscode "ms-vscode.remote-explorer"
-vscode "ms-vscode.remote-server"
-vscode "ms-vscode.vscode-typescript-next"
-vscode "neilding.language-liquid"
-vscode "nicoespeon.abracadabra"
-vscode "orta.vscode-jest"
-vscode "redhat.vscode-yaml"
-vscode "shopify.ruby-lsp"
-vscode "shopify.theme-check-vscode"
-vscode "sissel.shopify-liquid"
-vscode "visualstudiotoolsforunity.vstuc"
-vscode "yzhang.markdown-all-in-one"
+cask 'zoom'
+mas '1Password for Safari', id: 1_569_813_296
+mas '24 Hour Wallpaper', id: 1_226_087_575
+mas '2FAS - Two Factor Authentication', id: 6_443_941_139
+mas 'AdGuard for Safari', id: 1_440_147_259
+mas 'Dark Reader for Safari', id: 1_438_243_180
+mas 'DuckDuckGo Privacy for Safari', id: 1_482_920_575
+mas 'GhostText', id: 1_552_641_506
+mas 'Hush', id: 1_544_743_900
+mas 'HyperList', id: 0
+mas 'iMovie', id: 408_981_434
+mas 'JSON Peep', id: 1_458_969_831
+mas 'Keynote', id: 409_183_694
+mas 'Kindle', id: 302_584_613
+mas 'LanguageTool', id: 1_534_275_760
+mas 'MeetingBar', id: 1_532_419_400
+mas 'Meshtastic', id: 1_586_432_531
+mas 'Okta Extension App', id: 1_439_967_473
+mas 'Open In Webmail', id: 1_451_552_749
+mas 'PayPal Honey', id: 1_472_777_122
+mas 'Push Security', id: 1_596_916_655
+mas 'reMarkable', id: 1_276_493_162
+mas 'RetailMeNot Codes & Cash Back', id: 1_588_381_926
+mas 'Ring', id: 1_142_753_258
+mas 'StopTheMadness', id: 1_376_402_589
+mas 'Super Agent', id: 1_568_262_835
+mas 'TestFlight', id: 899_247_664
+mas 'URL Linker', id: 1_289_119_450
+mas 'Wayback Machine', id: 1_472_432_422
+mas 'WhatsApp', id: 310_633_997
+vscode '1password.op-vscode'
+vscode 'astro-build.astro-vscode'
+vscode 'christian-kohler.npm-intellisense'
+vscode 'datadog.datadog-vscode'
+vscode 'davidanson.vscode-markdownlint'
+vscode 'docker.docker'
+vscode 'ginfuru.ginfuru-vscode-jekyll-syntax'
+vscode 'github.codespaces'
+vscode 'github.copilot-chat'
+vscode 'github.copilot-workspace'
+vscode 'github.github-vscode-theme'
+vscode 'github.vscode-github-actions'
+vscode 'github.vscode-pull-request-github'
+vscode 'kargware.vscode-extension-jekyll-kw'
+vscode 'mechatroner.rainbow-csv'
+vscode 'ms-azuretools.vscode-containers'
+vscode 'ms-dotnettools.csdevkit'
+vscode 'ms-dotnettools.csharp'
+vscode 'ms-dotnettools.vscode-dotnet-runtime'
+vscode 'ms-vscode-remote.remote-containers'
+vscode 'ms-vscode-remote.remote-ssh'
+vscode 'ms-vscode-remote.remote-ssh-edit'
+vscode 'ms-vscode-remote.remote-wsl'
+vscode 'ms-vscode-remote.vscode-remote-extensionpack'
+vscode 'ms-vscode.makefile-tools'
+vscode 'ms-vscode.remote-explorer'
+vscode 'ms-vscode.remote-server'
+vscode 'ms-vscode.vscode-typescript-next'
+vscode 'neilding.language-liquid'
+vscode 'nicoespeon.abracadabra'
+vscode 'orta.vscode-jest'
+vscode 'petercort.copilot-enabler'
+vscode 'redhat.vscode-yaml'
+vscode 'shopify.ruby-lsp'
+vscode 'shopify.theme-check-vscode'
+vscode 'sissel.shopify-liquid'
+vscode 'visualstudiotoolsforunity.vstuc'
+vscode 'yzhang.markdown-all-in-one'

--- a/Brewfile
+++ b/Brewfile
@@ -130,7 +130,7 @@ brew 'mas'
 brew 'openjdk'
 # Java-based project management
 brew 'maven'
-# Polyglot runtime manager (asdf rust clone)
+# Polyglot runtime manager
 brew 'mise'
 # 'traceroute' and 'ping' in a single tool
 brew 'mtr'

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,136 @@
+# Migration Runbook
+
+A checklist for setting up a new Mac from these dotfiles. Re-runnable: every
+step is idempotent, so it's safe to start over if something goes sideways.
+
+## 1. On the old machine (before migrating)
+
+- [ ] Commit and push every working tree under `~/projects` and `~/github`
+      (including `.env` files into a password manager — do not commit them):
+      ```sh
+      for dir in ~/projects/* ~/github/*; do
+        [ -d "$dir/.git" ] && (cd "$dir" && git status --short && git stash list)
+      done
+      ```
+- [ ] Refresh this repo so the new machine inherits a current state:
+      ```sh
+      cd ~/.files
+      script/update-brewfile   # syncs Brewfile to actually-installed packages
+      script/lint && script/test
+      git commit -am "Pre-migration sync"
+      git push
+      ```
+- [ ] Verify 1Password vault is fully synced (Settings → status indicator).
+      All SSH keys and the git commit-signing key live here.
+- [ ] Verify Dropbox is fully synced (Mackup syncs via `~/Dropbox/mackup`).
+- [ ] Run Mackup backup if not already up to date: `mackup backup`.
+- [ ] (Optional) Export GPG secret keys — only if you still use GPG for
+      email/encryption. Git commit signing uses SSH via 1Password and does
+      not need this.
+      ```sh
+      gpg --export-secret-keys --armor > ~/gpg-secret-keys.asc
+      gpg --export-ownertrust > ~/gpg-ownertrust.txt
+      # Stash both in 1Password as secure notes; delete from disk.
+      ```
+- [ ] Note any GUI apps installed manually (not via `Brewfile`) so you can
+      decide whether to add them to `Brewfile` or reinstall by hand.
+
+## 2. On the new machine — prerequisites
+
+These cannot be automated by the playbook because they require GUI sign-in or
+must exist before `script/setup` runs.
+
+- [ ] Sign in to **Apple ID / iCloud** (System Settings → top of sidebar).
+- [ ] Sign in to the **App Store** (required before `mas` can install ~25
+      Mac App Store apps from `Brewfile`).
+- [ ] Install Xcode Command Line Tools:
+      ```sh
+      xcode-select --install
+      ```
+- [ ] Install Homebrew:
+      ```sh
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      ```
+- [ ] Install **1Password** (App Store or `brew install --cask 1password`),
+      sign in, then enable:
+      - Settings → Developer → **Use the SSH agent** ✓
+      - Settings → Developer → **Integrate with 1Password CLI** ✓
+      - Install the **1Password browser extension** in your default browser.
+- [ ] Install **Dropbox**, sign in, and let it fully sync `~/Dropbox/mackup`
+      before running Mackup restore.
+
+## 3. Clone and run setup
+
+```sh
+git clone https://github.com/benbalter/dotfiles ~/.files
+cd ~/.files
+script/setup
+```
+
+What to expect:
+
+- Bootstrap creates a Python venv and installs Ansible.
+- Ansible installs every formula, cask, Mac App Store app, and VS Code
+  extension from `Brewfile`. **First run takes 20–60 minutes.**
+- You will be prompted for `sudo` (system defaults, firewall) and may see
+  App Store prompts if any `mas` app needs review.
+- Re-running is safe — every task is idempotent.
+
+## 4. Verify
+
+- [ ] **Git commit signing** — should sign automatically via 1Password:
+      ```sh
+      cd /tmp && git init signtest && cd signtest
+      git commit --allow-empty -S -m "test"
+      git log --show-signature -1   # expect "Good signature"
+      ```
+- [ ] **GitHub auth**:
+      ```sh
+      gh auth status
+      ```
+- [ ] **Mac App Store apps installed**:
+      ```sh
+      mas list | wc -l   # expect ~25
+      ```
+- [ ] **VS Code extensions installed**:
+      ```sh
+      code --list-extensions | wc -l
+      ```
+- [ ] **LaunchAgents loaded** (tmpreaper for Downloads, auto-update):
+      ```sh
+      launchctl list | grep balter
+      ```
+- [ ] **Dock** matches `config.yml` (Chrome, Spotify, VS Code, Slack pinned;
+      Mail / Calendar / Maps / etc. removed).
+- [ ] **Shell** is zsh with oh-my-zsh + starship prompt.
+
+## 5. Manual data transfer (after setup)
+
+These are **not** managed by the playbook — copy or restore as needed.
+
+- [ ] **Mackup restore** (zsh history, app-specific prefs):
+      ```sh
+      mackup restore
+      ```
+- [ ] **Working repos**: clone fresh from GitHub, or `rsync ~/projects` and
+      `~/github` from the old machine.
+- [ ] **`~/.ssh/known_hosts`** (optional — will rebuild as you connect):
+      ```sh
+      scp old-mac:~/.ssh/known_hosts ~/.ssh/
+      ```
+- [ ] **GPG keyring** (optional, only if exported in step 1):
+      ```sh
+      gpg --import ~/gpg-secret-keys.asc
+      gpg --import-ownertrust ~/gpg-ownertrust.txt
+      ```
+- [ ] **Browser profiles** — sign in to Chrome/Safari to sync; or import
+      bookmarks manually.
+- [ ] **iMessage / Messages history** — handled by iCloud if enabled.
+- [ ] **Photos library** — iCloud Photos.
+
+## 6. Decommission the old machine
+
+- [ ] One last `git push` of every working tree.
+- [ ] Confirm 1Password and Dropbox say "Up to date".
+- [ ] Sign out of iCloud, App Store, and iMessage (System Settings).
+- [ ] Erase all content and settings.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,6 +34,18 @@ step is idempotent, so it's safe to start over if something goes sideways.
       ```
 - [ ] Note any GUI apps installed manually (not via `Brewfile`) so you can
       decide whether to add them to `Brewfile` or reinstall by hand.
+- [ ] Capture custom `/etc/hosts` entries (not managed by dotfiles):
+      ```sh
+      grep -v '^#' /etc/hosts | grep -vE '^(127\.|255\.|::1)' > ~/hosts-custom.txt
+      ```
+      Known custom entry: `192.168.1.36 dns.balter.com`.
+- [ ] Export iTerm2 preferences (not in dotfiles):
+      Preferences → General → Preferences → "Save current settings to folder"
+      and point at a synced folder (e.g., `~/Dropbox/iterm2`). Or accept
+      defaults on the new machine — Ghostty config already travels in dotfiles.
+- [ ] Confirm **VS Code Settings Sync** is enabled (Settings → Settings Sync,
+      signed in with GitHub). The playbook installs extensions but not user
+      settings/keybindings.
 
 ## 2. On the new machine — prerequisites
 
@@ -112,6 +124,16 @@ These are **not** managed by the playbook — copy or restore as needed.
       ```sh
       mackup restore
       ```
+      Note: as of last audit, `~/Dropbox/mackup` had not been updated in
+      ~6 months. Run `mackup backup` on the old machine first, or accept
+      that whatever's there is what you'll restore.
+- [ ] **`/etc/hosts` custom entries** — append from `~/hosts-custom.txt`:
+      ```sh
+      sudo sh -c "cat ~/hosts-custom.txt >> /etc/hosts"
+      ```
+- [ ] **iTerm2 preferences** — Preferences → General → Preferences →
+      "Load preferences from custom folder" pointing at the same synced
+      folder used in step 1.
 - [ ] **Working repos**: clone fresh from GitHub, or `rsync ~/projects` and
       `~/github` from the old machine.
 - [ ] **`~/.ssh/known_hosts`** (optional — will rebuild as you connect):


### PR DESCRIPTION
Audit + runbook for migrating to a new MacBook.

## Audit changes
- Removed stray empty directory `1` at repo root
- Refreshed `Brewfile` via `script/update-brewfile` so it matches actually-installed packages (renames: `mise`→`asdf`, `delta`→`git-delta`; adds: `gitleaks`, `terraform`, `pdftk-java`, `ghostscript`, `azure-cli`, etc.)
- Verified `.mackup.cfg` engine (Dropbox is still in use, no change)
- All linters and tests pass on the current machine

## New `MIGRATION.md` runbook
Six sections:
1. Pre-migration tasks on the old machine (push repos, sync 1Password & Dropbox, optional GPG export)
2. New-machine prerequisites that can't be automated (Apple ID, App Store, Xcode CLT, Homebrew, 1Password SSH agent, Dropbox)
3. `git clone` + `script/setup`
4. Verification checklist (signed test commit, `gh auth status`, `mas list`, `launchctl`, Dock)
5. Manual data transfer (Mackup restore, repos, GPG, browsers)
6. Decommission old machine

Re-runnable for future migrations.