### PR TITLE
Install dockutil via the dock role in CI

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -163,7 +163,8 @@
     # Mirrors the Linux Brewfile task: --no-upgrade so already-installed,
     # self-updating casks (Chrome, Slack, VS Code, …) are treated as satisfied
     # rather than force-upgraded, which fails on their auto-updated app bundles.
-    # Skipped in CI, which installs a minimal Brewfile subset separately.
+    # Skipped in CI: installing the full app/cask set there is unnecessary, and
+    # jobs that need specific tools install them directly.
     - name: Install Brewfile packages
       ansible.builtin.command:
         cmd: "{{ homebrew_brew_bin_path }}/brew bundle install --file={{ playbook_dir }}/Brewfile --no-upgrade"
@@ -343,9 +344,11 @@
         apply:
           tags: [macos, dock]
       vars:
-        # dockutil is installed via the Brewfile; skip the role's own install
-        # task, whose homebrew module call would trip the Workbrew wrapper.
-        dockutil_install: false
+        # On real hardware dockutil comes from the Brewfile, and letting the
+        # role install it via its homebrew module would trip the Workbrew
+        # wrapper. CI skips the full Brewfile (and has no Workbrew), so let the
+        # role install dockutil itself there.
+        dockutil_install: "{{ is_ci }}"
       when: is_macos
       tags: [macos, dock]
 


### PR DESCRIPTION
## Problem

CI has been failing on `main` (and therefore on every open PR, including the actions/cache bump in #82) since **f2dca1d "Route Homebrew through the Workbrew wrapper"**:

```
[ERROR]: Task failed: Module failed: Error executing command: [Errno 2] No such file or directory: b'dockutil'
fatal: [localhost]: FAILED! => {"cmd": "dockutil --add '/Applications/Google Chrome.app/' ...", "rc": 2}
```

## Root cause

- The macOS Brewfile install is gated `when: is_macos and not is_ci`, so `dockutil` (declared in the Brewfile) is **not** installed in CI.
- f2dca1d set `dockutil_install: false` on the `geerlingguy.mac.dock` role because the role's `community.general.homebrew` call trips the Workbrew wrapper — but that wrapper only exists on real hardware, not on GitHub runners.
- Net result: in CI nothing installs `dockutil`, and the dock role's `dockutil --add` fails.

## Fix

Scope the skip to non-CI with `dockutil_install: "{{ is_ci }}"`, so the role installs `dockutil` itself in CI (mirroring the `not is_ci` gate on the Brewfile task). This restores the pre-f2dca1d behavior, where `dockutil_install` defaulted to `true` and CI was green.

Also corrects a stale comment claiming CI installs a "minimal Brewfile subset separately" — `script/bootstrap` does no such thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)